### PR TITLE
Pull in a newer Fauxhai than is in the most recent Chef-DK

### DIFF
--- a/files/Gemfile
+++ b/files/Gemfile
@@ -6,5 +6,6 @@ end
 
 source 'https://rubygems.org'
 
+gem 'fauxhai', '>= 6.1.0'
 gem 'rubocop', '>= 0.55'
 gem 'simplecov-console'


### PR DESCRIPTION
I want to start testing a couple things against Ubuntu 18.04 and that was only
recently added, not yet baked into the Chef-DK.