### PR TITLE
Undo the last change

### DIFF
--- a/files/Gemfile
+++ b/files/Gemfile
@@ -6,6 +6,5 @@ end
 
 source 'https://rubygems.org'
 
-gem 'fauxhai', '>= 6.1.0'
 gem 'rubocop', '>= 0.55'
 gem 'simplecov-console'


### PR DESCRIPTION
The newer Fauxhai requires a newer ChefSpec which ends up pulling in Chef 14 and
blowing up the Chef-DK. :(