### PR TITLE
Add Chef Workstation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A set of common files that can be shared between cookbooks.
 
 ***Bundler***
 
-The included `Gemfile` includes gems we commonly add on top of what comes packed with the Chef-DK. It can be imported into a cookbook as follows:
+The included `Gemfile` includes gems we commonly add on top of what comes packed with Chef Workstation/DK. It can be imported into a cookbook as follows:
 
 ```ruby
 # frozen_string_literal: true

--- a/files/Gemfile
+++ b/files/Gemfile
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
-unless ENV['PATH'].include?('chefdk')
-  raise(RuntimeError, 'This cookbook requires the Chef Development Kit')
-end
+paths = ENV['PATH'].split(':')
+chef_product = if paths.find { |p| p.match?(%r{/chef-workstation/bin$}) }
+                 'chef-workstation'
+               elsif paths.find { |p| p.match?(%r{/chefdk/bin$}) }
+                 'chefdk'
+               else
+                 raise('This cookbook requires Chef Workstation or the Chef ' \
+                       'Development Kit')
+               end
 
 source 'https://rubygems.org'
 
@@ -13,15 +19,15 @@ addon_gems = {
 }
 
 chef_path = if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
-              'C:\\opscode\\chefdk\\bin\\chef'
+              "C:\\opscode\\#{chef_product}\\bin\\chef"
             else
-              '/opt/chefdk/bin/chef'
+              "/opt/#{chef_product}/bin/chef"
             end
 
 File.read(chef_path).lines.each do |line|
   next unless line.strip.start_with?('gem ')
   name, _, version = line.split('"')[1..3]
-  next if addon_gems.keys.include?(name)
+  next if addon_gems.key?(name)
   gem name, version
 end
 

--- a/files/TESTING.md
+++ b/files/TESTING.md
@@ -4,7 +4,17 @@ This document describes the process for testing a Socrara cookbook.
 
 ## Prerequisites
 
-A working Chef Development Kit installation is required. The Chef-DK can be installed via...
+A working Chef Workstation or Chef Development Kit installation is required.
+
+Chef Workstation can be installed via...
+
+- Direct [download](https://downloads.chef.io/chef-workstation/)
+- Homebrew (`brew cask install chef-workstation`)
+- Chocolatey (`choco install chef-workstation`)
+- APT/YUM/shell script (documented [here](https://docs.chef.io/packages.html))
+- The [chef-ingredient cookbook](https://supermarket.chef.io/cookbooks/chef-ingredient)
+
+The Chef-DK can be installed via...
 
 - Direct [download](https://downloads.chef.io/chef-dk/)
 - Homebrew (`brew cask install chefdk`)
@@ -12,6 +22,7 @@ A working Chef Development Kit installation is required. The Chef-DK can be inst
 - APT/YUM/shell script (documented [here](https://docs.chef.io/packages.html))
 - The [chefdk cookbook](https://supermarket.chef.io/cookbooks/chefdk)
 - The [chef-dk cookbook](https://supermarket.chef.io/cookbooks/chef-dk)
+- The [chef-ingredient cookbook](https://supermarket.chef.io/cookbooks/chef-ingredient)
 
 The integration tests assume a running instance of Docker on the test machine. Docker can be installed via
 
@@ -24,7 +35,7 @@ The integration tests assume a running instance of Docker on the test machine. D
 
 ## Installing Dependencies
 
-Install additional gem dependencies into Chef-DK's Ruby environment:
+Install additional gem dependencies into Chef's Ruby environment:
 
 ```shell
 > chef exec bundle install


### PR DESCRIPTION
The eventual replacement for Chef-DK has its content in another directory.