### PR TITLE
Update to the new ChefSpec

### DIFF
--- a/files/Gemfile
+++ b/files/Gemfile
@@ -13,6 +13,7 @@ chef_product = if paths.find { |p| p.match?(%r{/chef-workstation/bin$}) }
 source 'https://rubygems.org'
 
 addon_gems = {
+  'chefspec' => '>= 7.3.0',
   'kitchen-microwave' => '>= 0.3.0',
   'rubocop' => '>=0.55',
   'simplecov-console' => nil


### PR DESCRIPTION
We already have one cookbook using the new ChefSpec syntax and will only have
more. The latest releases can no longer converge test cookbooks that use
definitions, but we can hopefully address that on a case-by-case basis by
either updating cookbooks to use custom resources or inserting test stubs.

This can be deleted as soon as a Chef-DK is released packaged with the new
ChefSpec.