### PR TITLE
Ignore long blocks in Inspec tests

### DIFF
--- a/files/.rubocop.yml
+++ b/files/.rubocop.yml
@@ -1,4 +1,5 @@
-# ChefSpec tests frequently include lengthy `describe` blocks.
+# ChefSpec and Inspec tests frequently include lengthy `describe` blocks.
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
+    - test/integration/**/*


### PR DESCRIPTION
Inspec tests can have lengthy `describe` and/or `control` blocks.