### PR TITLE
Fix Gemfile path finding on Windows

### DIFF
--- a/files/Gemfile
+++ b/files/Gemfile
@@ -1,31 +1,24 @@
 # frozen_string_literal: true
 
-paths = ENV['PATH'].split(':')
-chef_product = if paths.find { |p| p.match?(%r{/chef-workstation/bin$}) }
-                 'chef-workstation'
-               elsif paths.find { |p| p.match?(%r{/chefdk/bin$}) }
-                 'chefdk'
-               else
-                 raise('This cookbook requires Chef Workstation or the Chef ' \
-                       'Development Kit')
-               end
+path_sep = RUBY_PLATFORM.match?(/mswin|mingw|windows/) ? ';' : ':'
+chef_bin = ENV['PATH'].split(path_sep).first
+
+unless chef_bin.end_with?('/chef-workstation/bin') ||
+       chef_bin.end_with?('/chefdk/bin')
+  raise('This cookbook requires Chef Workstation or the Chef Development Kit')
+end
 
 source 'https://rubygems.org'
 
 addon_gems = {
-  'chefspec' => '>= 7.3.0',
+  'chefstyle' => '>= 0.12.0',
+  'cookstyle' => '>= 4.0.0',
   'kitchen-microwave' => '>= 0.3.0',
-  'rubocop' => '>=0.55',
+  'rubocop' => '>= 0.62.0',
   'simplecov-console' => nil
 }
 
-chef_path = if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
-              "C:\\opscode\\#{chef_product}\\bin\\chef"
-            else
-              "/opt/#{chef_product}/bin/chef"
-            end
-
-File.read(chef_path).lines.each do |line|
+File.read("#{chef_bin}/chef").lines.each do |line|
   next unless line.strip.start_with?('gem ')
   name, _, version = line.split('"')[1..3]
   next if name == 'chef-dk'


### PR DESCRIPTION
TIL the PATH environment on Windows has semicolons as a separator (presumably
because the paths all have "c:" drive letters in them).

This also removes the chefspec dep, as Chef-DK is now packaged with the version
we need.

It also augments the rubocop dep. Chef-DK now comes with 0.55, which stops
bundler from pulling in one of the newer versions that we've been using.
Further, cookstyle and chefstyle now depend on specific versions of rubocop,
so we can't go to the latest version or those two will blow everything up.