### PR TITLE
Bump max line length to 80 from 128.

### DIFF
--- a/files/.rubocop.yml
+++ b/files/.rubocop.yml
@@ -3,3 +3,5 @@ Metrics/BlockLength:
   Exclude:
     - spec/**/*
     - test/integration/**/*
+Metrics/LineLength:
+  Max: 128


### PR DESCRIPTION
80 chars is a reasonable guideline to try to stick to for actual code, but enforcing it
leads to absurdities such as:
```
  instance_eval(open('https://raw.githubusercontent.com/socrata-cookbooks/' \
                     'shared/master/files/Gemfile').read)
```
And:

```
  default['java']['jdk']['8']['x86_64']['checksum'] = 'f23a3e2b9decef82b74f850' \
	  '157580d929ab35e9f19be5e0a10c779b68be51d43'
```

This is actively harmful and error prone.  I'd actually advocate for >128, but the most
egregious examples I've seen so far are fixed by 128.