### PR TITLE
Re-pin Chef-DK and un-pin RuboCop

### DIFF
--- a/files/Gemfile
+++ b/files/Gemfile
@@ -10,10 +10,14 @@ end
 source 'https://rubygems.org'
 
 addon_gems = {
+  # Chefstyle and Cookstyle are both pinned to specific versions of RuboCop
+  # and we use rules in a newer one than what ships in Chef-DK 3.
   'chefstyle' => '>= 0.12.0',
   'cookstyle' => '>= 4.0.0',
+  # Microwave is a custom wrapper around Test Kitchen not distributed with
+  # Chef-DK.
   'kitchen-microwave' => '>= 0.3.0',
-  'rubocop' => '>= 0.62.0',
+  # We use SimpleCov to check code coverage in unit tests that support it.
   'simplecov-console' => nil
 }
 
@@ -21,7 +25,6 @@ File.read("#{chef_bin}/chef").lines.each do |line|
   next unless line.strip.start_with?('gem ')
 
   name, _, version = line.split('"')[1..3]
-  next if name == 'chef-dk'
 
   next if addon_gems.key?(name)
 


### PR DESCRIPTION
### Description

The RuboCop pin is redundant since Cookstyle and Chefstyle both depend on an
exact version. Chef-DK is once again being published to RubyGems so there's no
Bundler error that necessitates us skipping it.

### Issues Resolved

Builds are failing after trying to install a newer chef-dk gem and pave over the running one.

### Check List

- [x] All tests pass
- [x] Version has been bumped in metadata
- [x] Commits have been squashed, as appropriate
- [x] Commits include descriptive messages, subjects written in the imperative
