### PR TITLE
Disable BlockLength

### DIFF
--- a/files/.rubocop.yml
+++ b/files/.rubocop.yml
@@ -1,7 +1,12 @@
 # ChefSpec and Inspec tests frequently include lengthy `describe` blocks.
 Metrics/BlockLength:
-  Exclude:
-    - spec/**/*
-    - test/integration/**/*
+  Enabled: False
+
+# Since we are completely disabling the BlockLength, cookbooks that contain a
+# rubocop directive of, `# rubocop:disable Metrics/BlockLength`, will complain
+# about unneccessary directives.
+Lint/UnneededCopDisableDirective:
+  Enabled: False
+
 Metrics/LineLength:
   Max: 128


### PR DESCRIPTION
### Description

Disabled the BlockLength rubocop rule since no other languages seem to
have this rule and it really bring any value add.  It may reduce some
complexity but probably not.  It's just loud and abnoxious.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] CHANGELOG has been updated
- [x] Version has been bumped in metadata
- [ ] Commits have been squashed, as appropriate
- [ ] Commits include descriptive messages, subjects written in the imperative
