### PR TITLE
Pin test-kitchen gem to a version compatible with ruby 2.5

### DIFF
--- a/files/Gemfile
+++ b/files/Gemfile
@@ -17,6 +17,8 @@ addon_gems = {
   'rubocop' => nil,
   'strings' => nil,
   'unicode-display_width' => nil,
+  # test-kitchen is used by microwave and kitchen, newer versions don't work with ruby 2.5
+  'test-kitchen' => '< 3.1.0'
   # Microwave is a custom wrapper around Test Kitchen not distributed with
   # Chef-DK.
   'kitchen-microwave' => '>= 0.3.0',


### PR DESCRIPTION
### Description

test-kitchen released an updated version that dropped support for ruby 2.5, this pins the version we use to one that's still compatible with 2.5

### Check List

- [x] Commits have been squashed, as appropriate
- [x] Commits include descriptive messages, subjects written in the imperative
